### PR TITLE
fix(Formatter): class method use `.` and instance method use `#`.

### DIFF
--- a/src/formatters/default/signature.cr
+++ b/src/formatters/default/signature.cr
@@ -66,7 +66,7 @@ module Docr::Formatters
 
       if with_parent && (parent = type.parent)
         io << format_path parent.full_name, :blue
-        io << '.'
+        io << (type.html_id.ends_with?("-class-method") ? "." : "#")
       elsif with_self
         io << "self.".colorize.magenta
       end


### PR DESCRIPTION
![Screenshot_20250510-101253__01](https://github.com/user-attachments/assets/98f12b2b-29ad-410e-92ed-a280fb4126d9)
